### PR TITLE
Fixes to properly escape all things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ fastlane/test_output
 iOSInjectionProject/
 .theos/
 .DS_Store
-
+packages

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,3 @@ internal-stage::
 	mkdir -p "$(THEOS_STAGING_DIR)/Library/Application Support/PasteAndGo2.bundle"
 	cp -R Resources/* "$(THEOS_STAGING_DIR)/Library/Application Support/PasteAndGo2.bundle/"
 
-after-install::
-	install.exec "killall -9 SpringBoard"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ It is based on [u/apieceoflint's](https://reddit.com/u/apieceoflint)'s' PasteAnd
  - Chrome
  - Edge
  - Firefox
+ - Firefox Focus
  - Brave
 
 ## Installation

--- a/Tweak.x
+++ b/Tweak.x
@@ -1,5 +1,5 @@
-//Hooks are from https://github.com/opa334/Choicy/blob/master/ChoicySB/TweakSB.x
-//This code implements new features to https://github.com/lint/PasteAndGo/, so please make sure to go star their repo as well! ;)
+// Hooks are from https://github.com/opa334/Choicy/blob/master/ChoicySB/TweakSB.x
+// This code implements new features to https://github.com/lint/PasteAndGo/, so please make sure to go star their repo as well! ;)
 
 #import "PasteAndGo2.h"
 
@@ -11,7 +11,7 @@
 %hook SBIconView
 
 %new
--(bool) isBrowser:(NSString *)bundleID { //hardcoded function because I'm tired and lazy
+-(bool) isBrowser:(NSString *)bundleID { // hardcoded function because I'm tired and lazy
 	if ([bundleID isEqualToString:@"com.apple.mobilesafari"]
 		|| [bundleID isEqualToString:@"org.mozilla.ios.Firefox"]
 		|| [bundleID isEqualToString:@"org.mozilla.ios.Focus"]
@@ -51,7 +51,7 @@
 			
 			NSURL *url = [NSURL URLWithString:[pbStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
 			
-			if ([[UIApplication sharedApplication] canOpenURL:url]) { //Item copied is an URL
+			if ([[UIApplication sharedApplication] canOpenURL:url]) { // Item copied is an URL
 
 				SBSApplicationShortcutItem* pasteAndGoItem = [[%c(SBSApplicationShortcutItem) alloc] init];
 				pasteAndGoItem.localizedTitle = [tweakBundle localizedStringForKey:@"PASTEANDGO" value:@"" table:nil];
@@ -61,7 +61,7 @@
 
 				return [orig arrayByAddingObject:pasteAndGoItem];
 
-			} else { //Item copied is not an URL
+			} else { // Item copied is not an URL
 
 				SBSApplicationShortcutItem* pasteAndGoItem = [[%c(SBSApplicationShortcutItem) alloc] init];
 				pasteAndGoItem.localizedTitle = [tweakBundle localizedStringForKey:@"PASTEANDSEARCH" value:@"" table:nil];
@@ -78,7 +78,7 @@
 	return orig;
 }
 
-+(void) activateShortcut:(SBSApplicationShortcutItem*)item withBundleIdentifier:(NSString*)bundleID forIconView:(id)iconView{
++(void) activateShortcut:(SBSApplicationShortcutItem*)item withBundleIdentifier:(NSString*)bundleID forIconView:(id)iconView {
 	
 	if ([[item type] isEqualToString:@"com.twickd.amodrono.pasteandgo2.item"]){
 		
@@ -87,45 +87,86 @@
 		
 		if (pbStr) {
 
+			pbStr = [pbStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 			NSString * urlScheme;
+			BOOL needToEscapeURL = NO;
+			BOOL needToRemoveSchema = NO;
 
 			if ([bundleID isEqualToString:@"org.mozilla.ios.Firefox"]) {
 				urlScheme = @"firefox://open-url?url=";
+				needToEscapeURL = YES;
 			} else if ([bundleID isEqualToString:@"org.mozilla.ios.Focus"]) {
 				urlScheme = @"firefox-focus://open-url?url=";
+				needToEscapeURL = YES;
 			} else if ([bundleID isEqualToString:@"com.google.chrome.ios"]) {
-				urlScheme = @"googlechrome://";
+				if ([pbStr hasPrefix:@"https://"])
+					urlScheme = @"googlechromes://";
+				else
+					urlScheme = @"googlechrome://";
+				needToRemoveSchema = YES;
 			} else if ([bundleID isEqualToString:@"com.brave.ios.browser"]) {
 				urlScheme = @"brave://open-url?url=";
+				needToEscapeURL = YES;
 			} else if ([bundleID isEqualToString:@"com.microsoft.msedge"]) {
 				urlScheme = @"microsoft-edge-";
 			} else {
 				urlScheme = @"";
 			}
 
-			NSURL * finalURL = [NSURL URLWithString:[pbStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+			NSCharacterSet *customCharacterset = [[NSCharacterSet characterSetWithCharactersInString:@"!*'();:@&=+$,/?%#[]\\<>^`{|} "] invertedSet];
+			if (needToRemoveSchema) {
+				pbStr = [pbStr stringByReplacingOccurrencesOfString:@"http://" withString:@""];
+				pbStr = [pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""];
+			}
+			NSURL * finalURL = [NSURL URLWithString:pbStr];
 
-			if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:pbStr]]) {
+			if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:pbStr]] /*|| [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:[pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset]]]*/) {
 
-				pbStr = [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy];
+				//pbStr = [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy];
+				//if (needToEscapeURL) pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+				if (needToEscapeURL) pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
 
-				finalURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", urlScheme, [pbStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]]];
+				//finalURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", urlScheme, [pbStr mutableCopy]]];
+				finalURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", urlScheme, pbStr]];
 
-			} else { //item is not an url, so we just need to search it.
+			} else { // item is not an url, so we just need to search it.
 				
 				if ([bundleID isEqualToString:@"com.google.chrome.ios"]) {
 
 					pbStr = [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy];
-					finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@www.google.com/search?q=%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
+					finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@www.google.com/search?q=%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; // convert to google link
 				
 				} else {
 					
-					finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search?q=%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
-				
+					NSString *test;
+					if (needToEscapeURL) {
+						pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
+						pbStr = [pbStr stringByReplacingOccurrencesOfString:@"%" withString:@"%25"]; // second level escape is needed for the query
+						test = [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, pbStr];
+					} else {
+						pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
+						test = [NSString stringWithFormat:@"%@%@www.google.com/search?q=%@", urlScheme, needToRemoveSchema?@"":@"https://", pbStr];
+					}
+					
+
+					if (needToEscapeURL) {
+						//finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
+						//finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, [[[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset] mutableCopy]]]; //convert to google link
+						//NSString *test = [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, [[pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset] stringByReplacingOccurrencesOfString:@"%" withString:@"%25"]];
+						////HBLogDebug(@"test: %@", test);
+						////finalURL = [NSURL URLWithString: test]; //convert to google link
+					} else {
+						//finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search?q=%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
+						///////////finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search?q=%@", urlScheme, [pbStr stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]]]; //convert to google link
+					}
+					//finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@%@%@", urlScheme, [@"https://www.google.com/search?q=" stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]],[[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
+					HBLogDebug(@"test: %@", test);
+					finalURL = [NSURL URLWithString: test]; //convert to google link
 				}
 
 			}
 			
+			HBLogDebug(@"Final URL to open: %@", finalURL);
 			[[UIApplication sharedApplication] openURL:finalURL];
 
 		}
@@ -295,7 +336,7 @@
 %ctor{
 	
 	if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")){
-		%init(iOS13Up); //
+		%init(iOS13Up);
 	} else {
 		%init(iOS12OrDown);
 	}

--- a/Tweak.x
+++ b/Tweak.x
@@ -55,7 +55,7 @@
 
 				SBSApplicationShortcutItem* pasteAndGoItem = [[%c(SBSApplicationShortcutItem) alloc] init];
 				pasteAndGoItem.localizedTitle = [tweakBundle localizedStringForKey:@"PASTEANDGO" value:@"" table:nil];
-				pasteAndGoItem.localizedSubtitle = [NSString stringWithFormat: @"Go to: %@", [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy]]; //link without http:// and https://
+				pasteAndGoItem.localizedSubtitle = [NSString stringWithFormat: @"Go to: %@", [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy]]; // link without http:// and https://
 
 				pasteAndGoItem.type = @"com.twickd.amodrono.pasteandgo2.item";
 
@@ -120,49 +120,24 @@
 			}
 			NSURL * finalURL = [NSURL URLWithString:pbStr];
 
-			if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:pbStr]] /*|| [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:[pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset]]]*/) {
+			if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:pbStr]]) {
 
-				//pbStr = [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy];
-				//if (needToEscapeURL) pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
 				if (needToEscapeURL) pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
 
-				//finalURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", urlScheme, [pbStr mutableCopy]]];
 				finalURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", urlScheme, pbStr]];
 
-			} else { // item is not an url, so we just need to search it.
+			} else { // item is not an url, so we need to search it
 				
-				if ([bundleID isEqualToString:@"com.google.chrome.ios"]) {
-
-					pbStr = [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy];
-					finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@www.google.com/search?q=%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; // convert to google link
-				
+				if (needToEscapeURL) {
+					pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
+					pbStr = [pbStr stringByReplacingOccurrencesOfString:@"%" withString:@"%25"]; // second level escape is needed for the query
+					pbStr = [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, pbStr];
 				} else {
-					
-					NSString *test;
-					if (needToEscapeURL) {
-						pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
-						pbStr = [pbStr stringByReplacingOccurrencesOfString:@"%" withString:@"%25"]; // second level escape is needed for the query
-						test = [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, pbStr];
-					} else {
-						pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
-						test = [NSString stringWithFormat:@"%@%@www.google.com/search?q=%@", urlScheme, needToRemoveSchema?@"":@"https://", pbStr];
-					}
-					
-
-					if (needToEscapeURL) {
-						//finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
-						//finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, [[[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset] mutableCopy]]]; //convert to google link
-						//NSString *test = [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, [[pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset] stringByReplacingOccurrencesOfString:@"%" withString:@"%25"]];
-						////HBLogDebug(@"test: %@", test);
-						////finalURL = [NSURL URLWithString: test]; //convert to google link
-					} else {
-						//finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search?q=%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
-						///////////finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search?q=%@", urlScheme, [pbStr stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]]]; //convert to google link
-					}
-					//finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@%@%@", urlScheme, [@"https://www.google.com/search?q=" stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]],[[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
-					HBLogDebug(@"test: %@", test);
-					finalURL = [NSURL URLWithString: test]; //convert to google link
+					pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
+					pbStr = [NSString stringWithFormat:@"%@%@www.google.com/search?q=%@", urlScheme, needToRemoveSchema?@"":@"https://", pbStr];
 				}
+
+				finalURL = [NSURL URLWithString: pbStr];
 
 			}
 			
@@ -185,7 +160,7 @@
 %hook SBUIAppIconForceTouchControllerDataProvider
 
 %new
--(bool) isBrowser:(NSString *)bundleID { //hardcoded function because I'm tired and lazy
+-(bool) isBrowser:(NSString *)bundleID {
 	if ([bundleID isEqualToString:@"com.apple.mobilesafari"]
 		|| [bundleID isEqualToString:@"org.mozilla.ios.Firefox"]
 		|| [bundleID isEqualToString:@"org.mozilla.ios.Focus"]
@@ -219,11 +194,11 @@
 			
 			NSURL *url = [NSURL URLWithString:[pbStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
 			
-			if ([[UIApplication sharedApplication] canOpenURL:url]) {
+			if ([[UIApplication sharedApplication] canOpenURL:url]) { // Item copied is an URL
 				
 				SBSApplicationShortcutItem* pasteAndGoItem = [[%c(SBSApplicationShortcutItem) alloc] init];
 				pasteAndGoItem.localizedTitle = [tweakBundle localizedStringForKey:@"PASTEANDGO" value:@"" table:nil];
-				pasteAndGoItem.localizedSubtitle = [NSString stringWithFormat: @"Go to: %@", [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy]]; //link without http:// and https://
+				pasteAndGoItem.localizedSubtitle = [NSString stringWithFormat: @"Go to: %@", [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy]]; // link without http:// and https://
 
 				pasteAndGoItem.type = @"com.twickd.amodrono.pasteandgo2.item";
 
@@ -233,7 +208,7 @@
 					return [orig arrayByAddingObject:pasteAndGoItem];
 				}
 
-			} else { //Item copied is not an URL
+			} else { // Item copied is not an URL
 
 				SBSApplicationShortcutItem* pasteAndGoItem = [[%c(SBSApplicationShortcutItem) alloc] init];
 				pasteAndGoItem.localizedTitle = [tweakBundle localizedStringForKey:@"PASTEANDSEARCH" value:@"" table:nil];
@@ -287,40 +262,61 @@
 		
 		if (pbStr) {
 
+			pbStr = [pbStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 			NSString * urlScheme;
+			BOOL needToEscapeURL = NO;
+			BOOL needToRemoveSchema = NO;
 
 			if ([bundleID isEqualToString:@"org.mozilla.ios.Firefox"]) {
 				urlScheme = @"firefox://open-url?url=";
+				needToEscapeURL = YES;
 			} else if ([bundleID isEqualToString:@"org.mozilla.ios.Focus"]) {
 				urlScheme = @"firefox-focus://open-url?url=";
+				needToEscapeURL = YES;
 			} else if ([bundleID isEqualToString:@"com.google.chrome.ios"]) {
-				urlScheme = @"googlechrome://";
+				if ([pbStr hasPrefix:@"https://"])
+					urlScheme = @"googlechromes://";
+				else
+					urlScheme = @"googlechrome://";
+				needToRemoveSchema = YES;
 			} else if ([bundleID isEqualToString:@"com.brave.ios.browser"]) {
 				urlScheme = @"brave://open-url?url=";
+				needToEscapeURL = YES;
 			} else if ([bundleID isEqualToString:@"com.microsoft.msedge"]) {
 				urlScheme = @"microsoft-edge-";
 			} else {
 				urlScheme = @"";
 			}
 
-			NSURL * finalURL = [NSURL URLWithString:[pbStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+			NSCharacterSet *customCharacterset = [[NSCharacterSet characterSetWithCharactersInString:@"!*'();:@&=+$,/?%#[]\\<>^`{|} "] invertedSet];
+			if (needToRemoveSchema) {
+				pbStr = [pbStr stringByReplacingOccurrencesOfString:@"http://" withString:@""];
+				pbStr = [pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""];
+			}
+			NSURL * finalURL = [NSURL URLWithString:pbStr];
 
 			if ([[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:pbStr]]) {
 
-				pbStr = [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy];
-				finalURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", urlScheme, [pbStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]]];
+				if (needToEscapeURL) pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
 
-			} else { //item is not an url, so we just need to search it.
+				finalURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@", urlScheme, pbStr]];
+
+			} else { // item is not an url, so we need to search it
 				
-				if ([bundleID isEqualToString:@"com.google.chrome.ios"]) {
-					pbStr = [[[pbStr stringByReplacingOccurrencesOfString:@"https://" withString:@""] stringByReplacingOccurrencesOfString:@"http://" withString:@""] mutableCopy];
-					finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@www.google.com/search?q=%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
+				if (needToEscapeURL) {
+					pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
+					pbStr = [pbStr stringByReplacingOccurrencesOfString:@"%" withString:@"%25"]; // second level escape is needed for the query
+					pbStr = [NSString stringWithFormat:@"%@https://www.google.com/search%%3Fq%%3D%@", urlScheme, pbStr];
 				} else {
-					finalURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@https://www.google.com/search?q=%@", urlScheme, [[pbStr stringByReplacingOccurrencesOfString:@" " withString:@"+"] mutableCopy]]]; //convert to google link
+					pbStr = [pbStr stringByAddingPercentEncodingWithAllowedCharacters:customCharacterset];
+					pbStr = [NSString stringWithFormat:@"%@%@www.google.com/search?q=%@", urlScheme, needToRemoveSchema?@"":@"https://", pbStr];
 				}
+
+				finalURL = [NSURL URLWithString: pbStr];
 
 			}
 			
+			HBLogDebug(@"Final URL to open: %@", finalURL);
 			[[UIApplication sharedApplication] openURL:finalURL];
 
 		}
@@ -333,7 +329,7 @@
 
 %end
 
-%ctor{
+%ctor {
 	
 	if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"13.0")){
 		%init(iOS13Up);

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: com.amodrono.tweak.pasteandgo2
 Name: PasteAndGo2
 Depends: mobilesubstrate
-Version: 1.0.0
+Version: 1.1.0
 Architecture: iphoneos-arm
 Description: Directly search a word or go to a link from the force touch menu.
 Maintainer: amodrono


### PR DESCRIPTION
I refactored the URL opening function to properly escape URLs and queries in all cases. That fixes Firefox Focus support, as its parser didn't ignore invalid URLs as the only one apparently (as much as other browsers). This should also make adding other browsers in the future a very easy job, as with the two added booleans pretty much all schema cases should be covered.
Tested URLs and searching on:
* Firefox
* Firefox Focus
* Safari
* Microsoft Edge (and Chrome should be pretty much the same, not counting the removed scheme, feel free to test)

Test case for searching was:
```
did it work?!*'();:@&=+$,/?%%#[]\\<>^`{|}it did!!!
```

To grasp what had changed, it might be the easiest to look at the second commit in the iOS 12 section, as iOS 13 part was split into 2 commits.

I will appreciate adding me to the credits somewhere :D
Let me know if you have any questions about the changes